### PR TITLE
Add a way to notify about complete update of a section

### DIFF
--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/BaseSectionAdapter.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/BaseSectionAdapter.java
@@ -267,6 +267,18 @@ public abstract class BaseSectionAdapter<IVH extends BaseSectionAdapter.ItemView
     }
 
     /**
+     * Notifies SectionDataManager that items in section were replaced.
+     * <p>
+     * Note that this method does not notify about changes in header, you can use
+     * {@link SectionManager#updateSection(int)} for complete section update.
+     */
+    public final void notifyDataSetChanged() {
+        if (itemManager != null) {
+            itemManager.notifyDataSetChanged(section);
+        }
+    }
+
+    /**
      * Returns the 0-based index of the section currently represented by this BaseSectionAdapter in
      * RecyclerView.
      *

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/BaseSectionAdapter.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/BaseSectionAdapter.java
@@ -267,10 +267,14 @@ public abstract class BaseSectionAdapter<IVH extends BaseSectionAdapter.ItemView
     }
 
     /**
-     * Notifies SectionDataManager that items in section were replaced.
+     * Notifies SectionDataManager that all items in this section were changed.
      * <p>
-     * Note that this method does not notify about changes in header, you can use
+     * Similar to {@link android.support.v7.widget.RecyclerView.Adapter#notifyDataSetChanged()}.
+     * <p>
+     * Note that this method does not notify about changes in the header, you can use
      * {@link SectionManager#updateSection(int)} for complete section update.
+     * Also you can use {@link SectionAdapter#notifyHeaderChanged()} (int)} to update
+     * the header directly.
      */
     public final void notifyDataSetChanged() {
         if (itemManager != null) {

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
@@ -600,6 +600,23 @@ public class SectionDataManager implements SectionManager, PositionManager {
         }
 
         @Override
+        public void notifyDataSetChanged(int section) {
+            short sectionType = sectionToType.get(section);
+            SectionAdapterWrapper sectionAdapter = typeToAdapter.get(sectionType);
+            int oldItemsCount = getSectionItemCount(section);
+            int newItemsCount = sectionAdapter.getItemCount();
+            if (oldItemsCount < newItemsCount) {
+                notifyRangeInserted(section, oldItemsCount, newItemsCount - oldItemsCount);
+            } else if (newItemsCount < oldItemsCount) {
+                notifyRangeRemoved(section, newItemsCount, oldItemsCount - newItemsCount);
+            }
+            int changedCnt = Math.min(oldItemsCount, newItemsCount);
+            if (changedCnt > 0) {
+                notifyRangeChanged(section, 0, changedCnt);
+            }
+        }
+
+        @Override
         public void notifyMoved(int section, int fromPos, int toPos) {
             checkSectionIndex(section);
             checkSectionItemIndex(section, fromPos);

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
@@ -256,9 +256,23 @@ public class SectionDataManager implements SectionManager, PositionManager {
     @Override
     public void updateSection(int section) {
         checkSectionIndex(section);
-        adapter.notifyItemRangeChanged(getSectionFirstPos(section), getSectionRealItemCount(section));
+        short sectionType = sectionToType.get(section);
+        SectionAdapterWrapper sectionAdapter = typeToAdapter.get(sectionType);
+        int oldItemsCount = getSectionRealItemCount(section);
+        int newItemsCount = sectionAdapter.getItemCount() + sectionAdapter.getHeaderVisibilityInt();
+        updatePosSum(section, newItemsCount - oldItemsCount, false);
+        if (oldItemsCount < newItemsCount) {
+            adapter.notifyItemRangeInserted(getSectionFirstPos(section) + oldItemsCount,
+                    newItemsCount - oldItemsCount);
+        } else if (newItemsCount < oldItemsCount) {
+            adapter.notifyItemRangeRemoved(getSectionFirstPos(section) + newItemsCount,
+                    oldItemsCount - newItemsCount);
+        }
+        int changedCnt = Math.min(oldItemsCount, newItemsCount);
+        if (changedCnt > 0) {
+            adapter.notifyItemRangeChanged(getSectionFirstPos(section), changedCnt);
+        }
         if (headerManager != null) {
-            short sectionType = sectionToType.get(section);
             headerManager.updateHeaderView(sectionType);
         }
     }
@@ -601,6 +615,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
 
         @Override
         public void notifyDataSetChanged(int section) {
+            checkSectionIndex(section);
             short sectionType = sectionToType.get(section);
             SectionAdapterWrapper sectionAdapter = typeToAdapter.get(sectionType);
             int oldItemsCount = getSectionItemCount(section);

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionItemManager.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionItemManager.java
@@ -35,6 +35,7 @@ interface SectionItemManager {
     void notifyRangeInserted(int section, int startPos, int cnt);
     void notifyRangeRemoved(int section, int startPos, int cnt);
     void notifyRangeChanged(int section, int startPos, int cnt);
+    void notifyDataSetChanged(int section);
     void notifyMoved(int section, int fromPos, int toPos);
     void notifyHeaderChanged(int section);
     void notifyHeaderVisibilityChanged(int section, boolean visible);

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionManager.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionManager.java
@@ -200,6 +200,12 @@ public interface SectionManager {
 
     /**
      * Updates the section at the specified position in the RecyclerView.
+     * <p>
+     * In case section items count is changed, it will handle it as insert/remove of difference
+     * and update of intersection. For example, changing from 5 items to 3 triggers remove
+     * event for 4,5 and update event for 1, 2, 3.
+     * <p>
+     * Will also trigger header update, if section has one.
      *
      * @param section Index of the section to update.
      */


### PR DESCRIPTION
- Add notifyDataSetChanged method to BaseSectionAdapter
Previosly, there was no correct way to notify about complete
reset of data in adapter.
- Make SectionManager.updateSection handle section size updates 
Old implemenation of updateSection was expecting that section size
remains the same. Now it handles such changes and updates
sectionToPosSum properly.