### PR TITLE
Fix view holder wrapper inaccessible

### DIFF
--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/ViewHolderWrapper.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/ViewHolderWrapper.java
@@ -31,7 +31,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * {@link SectionDataManager}. Contains the corresponding {@link BaseSectionAdapter.ViewHolder} and
  * refers to the same View.
  */
-class ViewHolderWrapper extends RecyclerView.ViewHolder {
+public class ViewHolderWrapper extends RecyclerView.ViewHolder {
 
     final BaseSectionAdapter.ViewHolder viewHolder;
 

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/ViewHolderWrapper.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/ViewHolderWrapper.java
@@ -35,7 +35,7 @@ class ViewHolderWrapper extends RecyclerView.ViewHolder {
 
     final BaseSectionAdapter.ViewHolder viewHolder;
 
-    ViewHolderWrapper(BaseSectionAdapter.ViewHolder viewHolder) {
+    public ViewHolderWrapper(BaseSectionAdapter.ViewHolder viewHolder) {
         super(viewHolder.itemView);
         this.viewHolder = viewHolder;
     }


### PR DESCRIPTION
Hey there, just a small fix when using the library in a Kotlin project, Android Studio shows a nasty warning that `ViewHolderWrapper` is inaccessible. Looks like an issue with Java and Kotlin interop.