### PR TITLE
Add on header attached listener. Change visibility of getter methods of SectiondataManager and ViewHolderWrapper

### DIFF
--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
@@ -955,7 +955,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      * @param type Item view type.
      * @return True if the given type corresponds to header, false otherwise.
      */
-    private boolean isTypeHeader(int type) {
+    public boolean isTypeHeader(int type) {
         return (type >> 16) == NO_SECTION_TYPE;
     }
 
@@ -965,7 +965,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      *
      * @return Total number of items in RecyclerView.
      */
-    private int getTotalItemCount() {
+    public int getTotalItemCount() {
         return getSectionCount() > 0 ? sectionToPosSum.get(getSectionCount() - 1) : 0;
     }
 
@@ -976,7 +976,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      * @param viewHolder ViewHolder of the swiped view.
      * @return Corresponding SectionItemSwipeCallback if exists, or null.
      */
-    private SectionItemSwipeCallback getSwipeCallback(RecyclerView.ViewHolder viewHolder) {
+    public SectionItemSwipeCallback getSwipeCallback(RecyclerView.ViewHolder viewHolder) {
         int adapterPos = viewHolder.getAdapterPosition();
         if (!checkIndex(adapterPos, getTotalItemCount())) {
             return null;
@@ -995,7 +995,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      * @param pos     Item position.
      * @return Adapter position corresponding to the given section and position.
      */
-    private int getAdapterPos(int section, int pos) {
+    public int getAdapterPos(int section, int pos) {
         checkSectionIndex(section);
         short sectionType = sectionToType.get(section);
         SectionAdapterWrapper adapterWrapper = typeToAdapter.get(sectionType);
@@ -1009,7 +1009,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      * @param section Index of the section.
      * @return First global adapter position.
      */
-    private int getSectionFirstPos(int section) {
+    public int getSectionFirstPos(int section) {
         checkSectionIndex(section, true);
         return section > 0 ? sectionToPosSum.get(section - 1) : 0;
     }
@@ -1021,7 +1021,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      * @param section Index of the section.
      * @return Number of items.
      */
-    private int getSectionRealItemCount(int section) {
+    public int getSectionRealItemCount(int section) {
         checkSectionIndex(section);
         return sectionToPosSum.get(section) - (section > 0 ? sectionToPosSum.get(section - 1) : 0);
     }
@@ -1033,7 +1033,7 @@ public class SectionDataManager implements SectionManager, PositionManager {
      * @param section Index of the section.
      * @return Number of items.
      */
-    private int getSectionItemCount(int section) {
+    public int getSectionItemCount(int section) {
         short sectionType = sectionToType.get(section);
         SectionAdapterWrapper adapterWrapper = typeToAdapter.get(sectionType);
         return getSectionRealItemCount(section) - adapterWrapper.getHeaderVisibilityInt();

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/SectionDataManager.java
@@ -738,13 +738,8 @@ public class SectionDataManager implements SectionManager, PositionManager {
     }
 
     /**
-     * Register a listener that will be notified whenever a child view is attached to or detached
-     * from RecyclerView.
-     *
-     * <p>This listener will be called when a LayoutManager or the RecyclerView decides
-     * that a child view is no longer needed. If an application associates expensive
-     * or heavyweight data with item views, this may be a good place to release
-     * or free those resources.</p>
+     * Register a listener that will be notified whenever a header view is attached/pinned to the
+     * top of the screen.
      *
      * @param listener Listener to register
      */

--- a/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/ViewHolderWrapper.java
+++ b/sectionedrecyclerview/src/main/java/com/cruxlab/sectionedrecyclerview/lib/ViewHolderWrapper.java
@@ -31,9 +31,9 @@ import androidx.recyclerview.widget.RecyclerView;
  * {@link SectionDataManager}. Contains the corresponding {@link BaseSectionAdapter.ViewHolder} and
  * refers to the same View.
  */
-class ViewHolderWrapper extends RecyclerView.ViewHolder {
+public class ViewHolderWrapper extends RecyclerView.ViewHolder {
 
-    final BaseSectionAdapter.ViewHolder viewHolder;
+    public final BaseSectionAdapter.ViewHolder viewHolder;
 
     ViewHolderWrapper(BaseSectionAdapter.ViewHolder viewHolder) {
         super(viewHolder.itemView);


### PR DESCRIPTION
Hi, first of all, great library! I just wanted to add a listener interface for a case when a new header view is attached to the top of the screen. 
I have also made getter methods of `SectionDataManager` public, I couldn't see the reasoning of keeping them private, when they provide so much useful functionality and don't mess with internal processing.
I made `ViewHolderWrapper` and its `viewholder` member public. For example, to acess items' viewholder via `recyclerview.findViewHolderForAdapterPosition(pos);`. I kept its constructor package private, to ensure that instantiation is kept internal to library. This change also fixes Android Studio warning in Kotlin project when `sectionDataManager.adapter` is being accessed.